### PR TITLE
refactor: use partical flags

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,7 +41,7 @@ interface ITreeNode {
   children: Array<ITreeNode>
 }
 
-declare function runTree (flags: IFlags): Promise<ITreeRoot>;
+declare function runTree (flags: Partial<IFlags>): Promise<ITreeRoot>;
 
 declare module "tree-cli" {
   export=runTree


### PR DESCRIPTION
use `Partial` , so that I can choose some params but not all in typescript.

such as:

``` js
    tree({
      l:10,
      ignore:['node_modules','test']
    })
```